### PR TITLE
Fix list item padding shift on hover

### DIFF
--- a/theme/static/css/main.css
+++ b/theme/static/css/main.css
@@ -79,7 +79,6 @@
 
 .card_list li:hover {
   background-color: rgba(0, 0, 0, 0.02);
-  padding-left: 0.5rem;
 }
 
 [data-bs-theme="dark"] .card_list li:hover {


### PR DESCRIPTION
Remove padding-left from .card_list li:hover to prevent text from shifting when hovering over list items. The hover effect now only applies a subtle background color change.