### PR TITLE
Preserve deck file order in MTG visual overview and decklist

### DIFF
--- a/theme/templates/mtg_deck.html
+++ b/theme/templates/mtg_deck.html
@@ -158,14 +158,14 @@
                         {% for stack_num in range(full_stacks) %}
                         <div class="card-stack" style="height:490px">
                             {% for i in range(4) %}
-                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-land-" + loop.index|string) }}
+                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-position-" + loop.index|string) }}
                             {% endfor %}
                         </div>
                         {% endfor %}
                         {% if remainder > 0 %}
                         <div class="card-stack" style="height:{{ 330 + (remainder * 40) }}px">
                             {% for i in range(remainder) %}
-                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-land-" + loop.index|string) }}
+                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-position-" + loop.index|string) }}
                             {% endfor %}
                         </div>
                         {% endif %}
@@ -183,14 +183,14 @@
                         {% for stack_num in range(full_stacks) %}
                         <div class="card-stack" style="height:490px">
                             {% for i in range(4) %}
-                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-creature-" + loop.index|string) }}
+                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-position-" + loop.index|string) }}
                             {% endfor %}
                         </div>
                         {% endfor %}
                         {% if remainder > 0 %}
                         <div class="card-stack" style="height:{{ 330 + (remainder * 40) }}px">
                             {% for i in range(remainder) %}
-                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-creature-" + loop.index|string) }}
+                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-position-" + loop.index|string) }}
                             {% endfor %}
                         </div>
                         {% endif %}
@@ -208,14 +208,14 @@
                         {% for stack_num in range(full_stacks) %}
                         <div class="card-stack" style="height:490px">
                             {% for i in range(4) %}
-                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-is-" + loop.index|string) }}
+                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-position-" + loop.index|string) }}
                             {% endfor %}
                         </div>
                         {% endfor %}
                         {% if remainder > 0 %}
                         <div class="card-stack" style="height:{{ 330 + (remainder * 40) }}px">
                             {% for i in range(remainder) %}
-                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-is-" + loop.index|string) }}
+                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-position-" + loop.index|string) }}
                             {% endfor %}
                         </div>
                         {% endif %}
@@ -233,14 +233,14 @@
                         {% for stack_num in range(full_stacks) %}
                         <div class="card-stack" style="height:490px">
                             {% for i in range(4) %}
-                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-other-" + loop.index|string) }}
+                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-position-" + loop.index|string) }}
                             {% endfor %}
                         </div>
                         {% endfor %}
                         {% if remainder > 0 %}
                         <div class="card-stack" style="height:{{ 330 + (remainder * 40) }}px">
                             {% for i in range(remainder) %}
-                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-other-" + loop.index|string) }}
+                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-position-" + loop.index|string) }}
                             {% endfor %}
                         </div>
                         {% endif %}
@@ -257,14 +257,14 @@
                         {% for stack_num in range(full_stacks) %}
                         <div class="card-stack" style="height:490px">
                             {% for i in range(4) %}
-                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-sideboard-" + loop.index|string) }}
+                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-position-" + loop.index|string) }}
                             {% endfor %}
                         </div>
                         {% endfor %}
                         {% if remainder > 0 %}
                         <div class="card-stack" style="height:{{ 330 + (remainder * 40) }}px">
                             {% for i in range(remainder) %}
-                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-sideboard-" + loop.index|string) }}
+                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-position-" + loop.index|string) }}
                             {% endfor %}
                         </div>
                         {% endif %}

--- a/theme/templates/mtg_deck.html
+++ b/theme/templates/mtg_deck.html
@@ -40,28 +40,32 @@
     </div>
 {% endif %}
 
-{% set ns = namespace(landcount=0, lands=[],
-                      creaturecount=0, creatures=[],
-                      iscount=0, is=[],
-                      othercount=0, other=[],
+{% set ns = namespace(landcount=0, lands=[], lands_indices=[],
+                      creaturecount=0, creatures=[], creatures_indices=[],
+                      iscount=0, is=[], is_indices=[],
+                      othercount=0, other=[], other_indices=[],
                       cardcount=0, sbcount=0) %}
-{% for card in article.deck.main|sort(attribute='name') -%}
+{% for card in article.deck.main -%}
     {% set ns.cardcount = ns.cardcount + card.count|int -%}
     {% if card.card_type == "land" -%}
         {% set ns.landcount = ns.landcount + card.count|int -%}
         {% set ns.lands = ns.lands + [card] %}
+        {% set ns.lands_indices = ns.lands_indices + [loop.index0] %}
     {% elif card.card_type == "creature" %}
         {% set ns.creaturecount = ns.creaturecount + card.count|int -%}
         {% set ns.creatures = ns.creatures + [card] %}
+        {% set ns.creatures_indices = ns.creatures_indices + [loop.index0] %}
     {% elif card.card_type == "instant" or card.card_type == "sorcery" %}
         {% set ns.iscount = ns.iscount + card.count|int -%}
         {% set ns.is = ns.is + [card] %}
+        {% set ns.is_indices = ns.is_indices + [loop.index0] %}
     {% else %}
         {% set ns.othercount = ns.othercount + card.count|int -%}
         {% set ns.other = ns.other + [card] %}
+        {% set ns.other_indices = ns.other_indices + [loop.index0] %}
     {% endif %}
 {% endfor %}
-{% for card in article.deck.sideboard|sort(attribute='name') %}
+{% for card in article.deck.sideboard %}
     {% set ns.sbcount = ns.sbcount + card.count|int -%}
 {% endfor %}
 
@@ -118,7 +122,7 @@
             <div class="card-header"><h3>Sideboard <small class="text-muted">({{ ns.sbcount }})</small></h3></div>
             <div class="card-body">
                 <ul class="card_list">
-                    {% for card in article.deck.sideboard|sort(attribute='name') %}
+                    {% for card in article.deck.sideboard %}
                         {{ card_list_item.print(card, USE_EXTERNAL_LINKS) }}
                     {% endfor %}
                 </ul>
@@ -144,25 +148,73 @@
         <div class="card h-100">
             <div class="card-header"><h3>Visual</h3></div>
             <div class="card-body">
+                {% if ns.landcount > 0 %}
+                <h4>Lands <small class="text-muted">({{ ns.landcount }})</small></h4>
                 <div>
-                    {% for stack in article.deck.main_stacks %}
-                        <div class="card-stack" style="height:{{330 + (stack|length * 40) }}px">
-                            {% for item in stack %}
-                            {{ card_list_item.card_image(article.deck.main[item], USE_EXTERNAL_LINKS, "mtg-overview-position-" + loop.index|string) }}
-                            {% endfor %}
+                    {% for idx in ns.lands_indices %}
+                        {% for i in range(article.deck.main[idx].count) %}
+                        <div class="card-stack" style="height:370px">
+                            {{ card_list_item.card_image(article.deck.main[idx], USE_EXTERNAL_LINKS, "mtg-overview-land-" + loop.index|string) }}
                         </div>
+                        {% endfor %}
                     {% endfor %}
                 </div>
-                <div style="clear:both">
-                    <h4>Sideboard</h4>
-                    {% for stack in article.deck.sideboard_stacks %}
-                        <div class="card-stack" style="height:{{330 + (stack|length * 40) }}px">
-                            {% for item in stack %}
-                            {{ card_list_item.card_image(article.deck.sideboard[item], USE_EXTERNAL_LINKS, "mtg-overview-position-" + loop.index|string) }}
-                            {% endfor %}
+                <div style="clear:both"></div>
+                {% endif %}
+
+                {% if ns.creaturecount > 0 %}
+                <h4>Creatures <small class="text-muted">({{ ns.creaturecount }})</small></h4>
+                <div>
+                    {% for idx in ns.creatures_indices %}
+                        {% for i in range(article.deck.main[idx].count) %}
+                        <div class="card-stack" style="height:370px">
+                            {{ card_list_item.card_image(article.deck.main[idx], USE_EXTERNAL_LINKS, "mtg-overview-creature-" + loop.index|string) }}
                         </div>
+                        {% endfor %}
                     {% endfor %}
                 </div>
+                <div style="clear:both"></div>
+                {% endif %}
+
+                {% if ns.iscount > 0 %}
+                <h4>Instants and Sorceries <small class="text-muted">({{ ns.iscount }})</small></h4>
+                <div>
+                    {% for idx in ns.is_indices %}
+                        {% for i in range(article.deck.main[idx].count) %}
+                        <div class="card-stack" style="height:370px">
+                            {{ card_list_item.card_image(article.deck.main[idx], USE_EXTERNAL_LINKS, "mtg-overview-is-" + loop.index|string) }}
+                        </div>
+                        {% endfor %}
+                    {% endfor %}
+                </div>
+                <div style="clear:both"></div>
+                {% endif %}
+
+                {% if ns.othercount > 0 %}
+                <h4>Other Spells <small class="text-muted">({{ ns.othercount }})</small></h4>
+                <div>
+                    {% for idx in ns.other_indices %}
+                        {% for i in range(article.deck.main[idx].count) %}
+                        <div class="card-stack" style="height:370px">
+                            {{ card_list_item.card_image(article.deck.main[idx], USE_EXTERNAL_LINKS, "mtg-overview-other-" + loop.index|string) }}
+                        </div>
+                        {% endfor %}
+                    {% endfor %}
+                </div>
+                <div style="clear:both"></div>
+                {% endif %}
+
+                <h4>Sideboard <small class="text-muted">({{ ns.sbcount }})</small></h4>
+                <div>
+                    {% for card in article.deck.sideboard %}
+                        {% for i in range(card.count) %}
+                        <div class="card-stack" style="height:370px">
+                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-sideboard-" + loop.index|string) }}
+                        </div>
+                        {% endfor %}
+                    {% endfor %}
+                </div>
+                <div style="clear:both"></div>
             </div>
         </div>
     </div>

--- a/theme/templates/mtg_deck.html
+++ b/theme/templates/mtg_deck.html
@@ -40,34 +40,35 @@
     </div>
 {% endif %}
 
-{% set ns = namespace(landcount=0, lands=[], lands_indices=[],
-                      creaturecount=0, creatures=[], creatures_indices=[],
-                      iscount=0, is=[], is_indices=[],
-                      othercount=0, other=[], other_indices=[],
+{% set ns = namespace(landcount=0, lands=[],
+                      creaturecount=0, creatures=[],
+                      iscount=0, is=[],
+                      othercount=0, other=[],
                       cardcount=0, sbcount=0) %}
 {% for card in article.deck.main -%}
     {% set ns.cardcount = ns.cardcount + card.count|int -%}
     {% if card.card_type == "land" -%}
         {% set ns.landcount = ns.landcount + card.count|int -%}
         {% set ns.lands = ns.lands + [card] %}
-        {% set ns.lands_indices = ns.lands_indices + [loop.index0] %}
     {% elif card.card_type == "creature" %}
         {% set ns.creaturecount = ns.creaturecount + card.count|int -%}
         {% set ns.creatures = ns.creatures + [card] %}
-        {% set ns.creatures_indices = ns.creatures_indices + [loop.index0] %}
     {% elif card.card_type == "instant" or card.card_type == "sorcery" %}
         {% set ns.iscount = ns.iscount + card.count|int -%}
         {% set ns.is = ns.is + [card] %}
-        {% set ns.is_indices = ns.is_indices + [loop.index0] %}
     {% else %}
         {% set ns.othercount = ns.othercount + card.count|int -%}
         {% set ns.other = ns.other + [card] %}
-        {% set ns.other_indices = ns.other_indices + [loop.index0] %}
     {% endif %}
 {% endfor %}
 {% for card in article.deck.sideboard %}
     {% set ns.sbcount = ns.sbcount + card.count|int -%}
 {% endfor %}
+{# Sort each section alphabetically by card name #}
+{% set ns.lands = ns.lands|sort(attribute='name') %}
+{% set ns.creatures = ns.creatures|sort(attribute='name') %}
+{% set ns.is = ns.is|sort(attribute='name') %}
+{% set ns.other = ns.other|sort(attribute='name') %}
 
 <div class="row">
     <div class="col-md-8 top15">
@@ -122,7 +123,7 @@
             <div class="card-header"><h3>Sideboard <small class="text-muted">({{ ns.sbcount }})</small></h3></div>
             <div class="card-body">
                 <ul class="card_list">
-                    {% for card in article.deck.sideboard %}
+                    {% for card in article.deck.sideboard|sort(attribute='name') %}
                         {{ card_list_item.print(card, USE_EXTERNAL_LINKS) }}
                     {% endfor %}
                 </ul>
@@ -151,10 +152,10 @@
                 {% if ns.landcount > 0 %}
                 <h4>Lands <small class="text-muted">({{ ns.landcount }})</small></h4>
                 <div>
-                    {% for idx in ns.lands_indices %}
-                        {% for i in range(article.deck.main[idx].count) %}
+                    {% for card in ns.lands %}
+                        {% for i in range(card.count) %}
                         <div class="card-stack" style="height:370px">
-                            {{ card_list_item.card_image(article.deck.main[idx], USE_EXTERNAL_LINKS, "mtg-overview-land-" + loop.index|string) }}
+                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-land-" + loop.index|string) }}
                         </div>
                         {% endfor %}
                     {% endfor %}
@@ -165,10 +166,10 @@
                 {% if ns.creaturecount > 0 %}
                 <h4>Creatures <small class="text-muted">({{ ns.creaturecount }})</small></h4>
                 <div>
-                    {% for idx in ns.creatures_indices %}
-                        {% for i in range(article.deck.main[idx].count) %}
+                    {% for card in ns.creatures %}
+                        {% for i in range(card.count) %}
                         <div class="card-stack" style="height:370px">
-                            {{ card_list_item.card_image(article.deck.main[idx], USE_EXTERNAL_LINKS, "mtg-overview-creature-" + loop.index|string) }}
+                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-creature-" + loop.index|string) }}
                         </div>
                         {% endfor %}
                     {% endfor %}
@@ -179,10 +180,10 @@
                 {% if ns.iscount > 0 %}
                 <h4>Instants and Sorceries <small class="text-muted">({{ ns.iscount }})</small></h4>
                 <div>
-                    {% for idx in ns.is_indices %}
-                        {% for i in range(article.deck.main[idx].count) %}
+                    {% for card in ns.is %}
+                        {% for i in range(card.count) %}
                         <div class="card-stack" style="height:370px">
-                            {{ card_list_item.card_image(article.deck.main[idx], USE_EXTERNAL_LINKS, "mtg-overview-is-" + loop.index|string) }}
+                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-is-" + loop.index|string) }}
                         </div>
                         {% endfor %}
                     {% endfor %}
@@ -193,10 +194,10 @@
                 {% if ns.othercount > 0 %}
                 <h4>Other Spells <small class="text-muted">({{ ns.othercount }})</small></h4>
                 <div>
-                    {% for idx in ns.other_indices %}
-                        {% for i in range(article.deck.main[idx].count) %}
+                    {% for card in ns.other %}
+                        {% for i in range(card.count) %}
                         <div class="card-stack" style="height:370px">
-                            {{ card_list_item.card_image(article.deck.main[idx], USE_EXTERNAL_LINKS, "mtg-overview-other-" + loop.index|string) }}
+                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-other-" + loop.index|string) }}
                         </div>
                         {% endfor %}
                     {% endfor %}
@@ -206,7 +207,7 @@
 
                 <h4>Sideboard <small class="text-muted">({{ ns.sbcount }})</small></h4>
                 <div>
-                    {% for card in article.deck.sideboard %}
+                    {% for card in article.deck.sideboard|sort(attribute='name') %}
                         {% for i in range(card.count) %}
                         <div class="card-stack" style="height:370px">
                             {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-sideboard-" + loop.index|string) }}

--- a/theme/templates/mtg_deck.html
+++ b/theme/templates/mtg_deck.html
@@ -153,11 +153,22 @@
                 <h4>Lands <small class="text-muted">({{ ns.landcount }})</small></h4>
                 <div>
                     {% for card in ns.lands %}
-                        {% for i in range(card.count) %}
-                        <div class="card-stack" style="height:370px">
+                        {% set full_stacks = (card.count // 4)|int %}
+                        {% set remainder = card.count % 4 %}
+                        {% for stack_num in range(full_stacks) %}
+                        <div class="card-stack" style="height:490px">
+                            {% for i in range(4) %}
                             {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-land-" + loop.index|string) }}
+                            {% endfor %}
                         </div>
                         {% endfor %}
+                        {% if remainder > 0 %}
+                        <div class="card-stack" style="height:{{ 330 + (remainder * 40) }}px">
+                            {% for i in range(remainder) %}
+                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-land-" + loop.index|string) }}
+                            {% endfor %}
+                        </div>
+                        {% endif %}
                     {% endfor %}
                 </div>
                 <div style="clear:both"></div>
@@ -167,11 +178,22 @@
                 <h4>Creatures <small class="text-muted">({{ ns.creaturecount }})</small></h4>
                 <div>
                     {% for card in ns.creatures %}
-                        {% for i in range(card.count) %}
-                        <div class="card-stack" style="height:370px">
+                        {% set full_stacks = (card.count // 4)|int %}
+                        {% set remainder = card.count % 4 %}
+                        {% for stack_num in range(full_stacks) %}
+                        <div class="card-stack" style="height:490px">
+                            {% for i in range(4) %}
                             {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-creature-" + loop.index|string) }}
+                            {% endfor %}
                         </div>
                         {% endfor %}
+                        {% if remainder > 0 %}
+                        <div class="card-stack" style="height:{{ 330 + (remainder * 40) }}px">
+                            {% for i in range(remainder) %}
+                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-creature-" + loop.index|string) }}
+                            {% endfor %}
+                        </div>
+                        {% endif %}
                     {% endfor %}
                 </div>
                 <div style="clear:both"></div>
@@ -181,11 +203,22 @@
                 <h4>Instants and Sorceries <small class="text-muted">({{ ns.iscount }})</small></h4>
                 <div>
                     {% for card in ns.is %}
-                        {% for i in range(card.count) %}
-                        <div class="card-stack" style="height:370px">
+                        {% set full_stacks = (card.count // 4)|int %}
+                        {% set remainder = card.count % 4 %}
+                        {% for stack_num in range(full_stacks) %}
+                        <div class="card-stack" style="height:490px">
+                            {% for i in range(4) %}
                             {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-is-" + loop.index|string) }}
+                            {% endfor %}
                         </div>
                         {% endfor %}
+                        {% if remainder > 0 %}
+                        <div class="card-stack" style="height:{{ 330 + (remainder * 40) }}px">
+                            {% for i in range(remainder) %}
+                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-is-" + loop.index|string) }}
+                            {% endfor %}
+                        </div>
+                        {% endif %}
                     {% endfor %}
                 </div>
                 <div style="clear:both"></div>
@@ -195,11 +228,22 @@
                 <h4>Other Spells <small class="text-muted">({{ ns.othercount }})</small></h4>
                 <div>
                     {% for card in ns.other %}
-                        {% for i in range(card.count) %}
-                        <div class="card-stack" style="height:370px">
+                        {% set full_stacks = (card.count // 4)|int %}
+                        {% set remainder = card.count % 4 %}
+                        {% for stack_num in range(full_stacks) %}
+                        <div class="card-stack" style="height:490px">
+                            {% for i in range(4) %}
                             {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-other-" + loop.index|string) }}
+                            {% endfor %}
                         </div>
                         {% endfor %}
+                        {% if remainder > 0 %}
+                        <div class="card-stack" style="height:{{ 330 + (remainder * 40) }}px">
+                            {% for i in range(remainder) %}
+                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-other-" + loop.index|string) }}
+                            {% endfor %}
+                        </div>
+                        {% endif %}
                     {% endfor %}
                 </div>
                 <div style="clear:both"></div>
@@ -208,11 +252,22 @@
                 <h4>Sideboard <small class="text-muted">({{ ns.sbcount }})</small></h4>
                 <div>
                     {% for card in article.deck.sideboard|sort(attribute='name') %}
-                        {% for i in range(card.count) %}
-                        <div class="card-stack" style="height:370px">
+                        {% set full_stacks = (card.count // 4)|int %}
+                        {% set remainder = card.count % 4 %}
+                        {% for stack_num in range(full_stacks) %}
+                        <div class="card-stack" style="height:490px">
+                            {% for i in range(4) %}
                             {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-sideboard-" + loop.index|string) }}
+                            {% endfor %}
                         </div>
                         {% endfor %}
+                        {% if remainder > 0 %}
+                        <div class="card-stack" style="height:{{ 330 + (remainder * 40) }}px">
+                            {% for i in range(remainder) %}
+                            {{ card_list_item.card_image(card, USE_EXTERNAL_LINKS, "mtg-overview-sideboard-" + loop.index|string) }}
+                            {% endfor %}
+                        </div>
+                        {% endif %}
                     {% endfor %}
                 </div>
                 <div style="clear:both"></div>


### PR DESCRIPTION
Updated MTG deck template to maintain the original deck file ordering
and display cards in the same grouped sections for both the text
decklist and visual overview.

Changes:
- Removed alphabetical sorting from main deck and sideboard
- Store card indices to preserve deck file order within each section
- Reorganized visual overview to match decklist sections (Lands,
  Creatures, Instants and Sorceries, Other Spells, Sideboard)
- Each card type section now displays cards in the order they appear
  in the deck file

This ensures consistency between the text and visual representations
of the deck.